### PR TITLE
add Field Day to list of startups

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -226,6 +226,7 @@ This is an admittedly imperfect list of Portland startups. But it's a start. Ple
 - Epipheo
 - Factor.io
 - Favery
+- Field Day
 - Find Wellness
 - FishingGear.com
 - FitCause 


### PR DESCRIPTION
Adding Field Day, founded in Portland in summer 2021, launched our platform as GA in 9/2022.

More info at https://www.heyfieldday.com/