### PR TITLE
Remove Chinook Book

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -212,7 +212,6 @@ Active
 - Celly
 - CerCis Consulting
 - ChickTech
-- Chinook Book
 - chirpify
 - Chroma
 - Circle Media
@@ -592,6 +591,7 @@ Defunct
 
 - Brightwork (Defunct)
 - Bumped (Defunct)
+- Chinook Book (Defunct)
 - Clickety (Defunct)
 - CPUsage (Defunct)
 - Dovie (Defunct)


### PR DESCRIPTION
Chinook Book failed during the pandemic. https://www.oregonlive.com/business/2022/04/chinook-book-popular-portland-based-coupon-publisher-announces-abrupt-shutdown.html