### PR TITLE
Proposed startup removal from index.rst

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -239,7 +239,6 @@ Active
 - DailyPath
 - Dart
 - Dashdok
-- Deadstock Coffee
 - Deconstructed
 - Dedworks
 - Digital Trends


### PR DESCRIPTION
While Deadstock coffee is a fantastic company, I see no case for calling it a startup. If Deadstock is a startup, then hundreds of other local businesses are, too, and this list of startups becomes meaningless.