### PR TITLE
Added Fanlist

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -267,6 +267,7 @@ Active
 - Epipheo
 - Exterro
 - Factor.io
+- Fanlist (formerly known as PodInbox)
 - Fat Cupcake
 - Favery
 - Field Day


### PR DESCRIPTION
PodInbox is now Fanlist https://www.fanlist.com/podinbox-rebrands-as-fanlist/